### PR TITLE
Fix horizontal scrollbar always being on screen

### DIFF
--- a/components/MiniProjectCard.module.css
+++ b/components/MiniProjectCard.module.css
@@ -24,7 +24,6 @@
   background-color: gray;
   opacity: 50%;
   height: 100vh;
-  width: 100vw;
   top: 0;
   left: 0;
   z-index: 3;

--- a/components/Nav.module.css
+++ b/components/Nav.module.css
@@ -1,6 +1,5 @@
 .navbar_style {
   background-color: #fcfcf9;
-  width: 100vw;
   height: 100px;
   display: flex;
   align-items: center;
@@ -56,7 +55,6 @@
   color: black;
 }
 .footer_style {
-  width: 100vw;
   height: 200px;
 }
 .built_with {


### PR DESCRIPTION
Using 100vw causes an issue where page always can be scrolled horizontally. Without this CSS rule, page works well and doesn't have horizontal scrollbar.
![image](https://github.com/sbloxy123/stuart-bloxham-portfolio/assets/90870844/0cbfd741-a0a2-4fac-ad02-6d5713ac5a63)
